### PR TITLE
Allow every package to be imported through vsiew

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ Install `vsiew` with the following command:
 ```sh
 pip install vsiew
 ```
+
+## How to use
+
+Once you have installed this package, you can import all the IEW packages directly from vsiew:
+
+```py
+from vsiew import descale, BM3DCuda, depth
+```
+
+or populate your entire IDE with every IEW function using a star import:
+
+```py
+from vsiew import *
+```

--- a/vsiew/__init__.py
+++ b/vsiew/__init__.py
@@ -1,1 +1,18 @@
+# flake8: noqa
+
+from lvsfunc import *
+from vsaa import *
+from vsdeband import *
+from vsdehalo import *
+from vsdeinterlace import *
+from vsdenoise import *
+from vsdfft import *
+from vsexprtools import *
+from vskernels import *
+from vsmasktools import *
+from vsparsedvd import *
+from vsrgtools import *
+from vsscale import *
+from vstools import *
+
 from .init import update  # noqa: F401


### PR DESCRIPTION
Allowing users to star import all the packages makes it a lot easier to use for newbies. This also means that if you really want, you can simply import whatever you need without having to dive through all the existing packages.