### PR TITLE
Check if git is installed before updating to latest

### DIFF
--- a/vsjet/init.py
+++ b/vsjet/init.py
@@ -6,8 +6,12 @@ base_user = 'Jaded-Encoding-Thaumaturgy'
 def update(action_: list[str] | None) -> None:
     import re
     import sys
+    from shutil import which
     from subprocess import PIPE, Popen
     from typing import Iterator
+
+    if not which('git'):
+        raise ImportError('Git is not installed! Please install git before you continue.')
 
     action = 'update'
 


### PR DESCRIPTION
As can be seen with [these](https://discord.com/channels/1168547111139283026/1168620680850456696/1237872058050936892) config issues, running `vsjet latest` if `git` is not found completely removes all the JET packages from a user. This PR adds a quick check to ensure git is installed before it does anything else.